### PR TITLE
PROG-175 Jetson Configuration/Pipeline Structure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"python.formatting.provider": "black"
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,8 +5,8 @@
 if [ -z "$1" ] || [ -z "$2" ] ; then
     echo "No command line arguments given"
     echo "Defaulting connection to lightning@10.8.62.10"
-    rsync -zravP --delete ./voidvision/ lightning@10.8.62.10:/home/lightning/voidvision/
+    rsync -zravP ./voidvision/ lightning@10.8.62.10:/home/lightning/voidvision/
 else
     echo "Connecting to $1 at $2"
-    rsync -zravP --delete ./voidvision/ ${1}@${2}:/home/${1}/voidvision/
+    rsync -zravP ./voidvision/ ${1}@${2}:/home/${1}/voidvision/
 fi

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -15,12 +15,12 @@ apt install -y python3-cscore
 rm Release.key
 
 # setup /etc/hosts to connect to rio
-echo -e "10.8.62.10 roboRIO-862-FRC.lan" >> /etc/hosts # jetson ip on team image radio
-echo -e "10.8.62.10 roboRIO-862-FRC.frc-field.lan" >> /etc/hosts # jetson ip on fms image radio
+echo "10.8.62.10 roboRIO-862-FRC.lan" >> /etc/hosts # jetson ip on team image radio
+echo "10.8.62.10 roboRIO-862-FRC.frc-field.lan" >> /etc/hosts # jetson ip on fms image radio
 
 # make app environment
 mkdir -p /home/lightning/voidvision/
 touch /home/lightning/voidvision/runCamera # make sure this file exists - empty version will be overwritten on deploy
 
 # configure app to run on boot
-echo -e "@reboot sh /home/lightning/voidvision/runCamera" >> /etc/crontab
+echo "@reboot sh /home/lightning/voidvision/runCamera" >> /etc/crontab

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -15,10 +15,12 @@ apt install -y python3-cscore
 rm Release.key
 
 # setup /etc/hosts to connect to rio
-# TODO implement
+echo -e "10.8.62.10 roboRIO-862-FRC.lan" >> /etc/hosts # jetson ip on team image radio
+echo -e "10.8.62.10 roboRIO-862-FRC.frc-field.lan" >> /etc/hosts # jetson ip on fms image radio
 
 # make app environment
 mkdir -p /home/lightning/voidvision/
+touch /home/lightning/voidvision/runCamera # make sure this file exists - empty version will be overwritten on deploy
 
 # configure app to run on boot
-# TODO implement
+echo -e "@reboot sh /home/lightning/voidvision/runCamera" >> /etc/crontab

--- a/voidvision/camera-config.json
+++ b/voidvision/camera-config.json
@@ -9,7 +9,7 @@
 			"width": 640,
 			"height": 360,
 			"pixel format": "yuyv",
-			"fps": 60,
+			"fps": 10,
 			"stream": {
 				"properties": [
 					{
@@ -22,7 +22,7 @@
 					},
 					{
 					"name": "fps",
-					"value": 60
+					"value": 10
 					}
 				]
 			}

--- a/voidvision/camera-config.json
+++ b/voidvision/camera-config.json
@@ -1,7 +1,7 @@
 {
     "team": 862,
     "ntmode": "server",
-    "debug": false,   
+    "debug": true,   
     "cameras": [
 		{
 			"name": "cam",
@@ -11,22 +11,21 @@
 			"pixel format": "yuyv",
 			"fps": 60,
 			"stream": {
-			"properties": [
-				{
-				"name": "width",
-				"value": 640
-				},
-				{
-				"name": "height",
-				"value": 360
-				},
-				{
-				"name": "fps",
-				"value": 60
-				}
-			]
+				"properties": [
+					{
+					"name": "width",
+					"value": 640
+					},
+					{
+					"name": "height",
+					"value": 360
+					},
+					{
+					"name": "fps",
+					"value": 60
+					}
+				]
 			}
 		}
-    ],
-    "switched cameras": []
+    ]
 }

--- a/voidvision/camera.py
+++ b/voidvision/camera.py
@@ -3,9 +3,9 @@
 from cscore import CameraServer
 import json
 
-def start(configFile: str, cam_num: int, cam_name: str, output_name: str):
+def start(config_file: str, cam_num: int, cam_name: str, output_name: str):
 
-	with open(configFile) as cfg:
+	with open(config_file) as cfg:
 		config = json.load(cfg)
 	camera = config['cameras'][cam_num]
 	print(camera)

--- a/voidvision/camera.py
+++ b/voidvision/camera.py
@@ -14,7 +14,8 @@ def start(configFile: str, cam_num: int, cam_name: str, output_name: str):
 	height = camera['height']
 	
 	cs = CameraServer.getInstance()
-	cs.startAutomaticCapture(dev=cam_num, name=cam_name) # Returns `VideoSource`
+	cap = cs.startAutomaticCapture(dev=cam_num, name=cam_name) # Returns `VideoSource`
+	cap.setFPS(camera['fps'])
 
 	inp = cs.getVideo(name=cam_name) # Returns `CvSink`
 	out = cs.putVideo(name=output_name, width=width, height=height)

--- a/voidvision/dashboard.py
+++ b/voidvision/dashboard.py
@@ -9,7 +9,6 @@ def load(configFile: str):
 		config = json.load(cfg)
 	server = True if config['ntmode'] == 'server' else False
 	team = config['team']
-	print('is server: {}\nteam #: {}'.format(server, team))
 
 	ntinst = NetworkTablesInstance.getDefault()
 	if server:

--- a/voidvision/main.py
+++ b/voidvision/main.py
@@ -8,8 +8,8 @@ import json
 import numpy as np
 import time
 
-import voidvision.camera as camera
-import voidvision.dashboard as dashboard
+import camera
+import dashboard
 
 configFile = "/home/lightning/voidvision/camera-config.json"
 

--- a/voidvision/main.py
+++ b/voidvision/main.py
@@ -10,37 +10,31 @@ import time
 
 import camera
 import dashboard
+import pipelineloader
 
-configFile = "/home/lightning/voidvision/camera-config.json"
+config = "/home/lightning/voidvision/vision-config.json"
 
 def main():
-	
-	# one camera thing
-	inp, out, width, height = camera.start(configFile, 0, 'cam', 'output?')
 
 	# start dashboard
-	table = dashboard.load(configFile)
+	table = dashboard.load(config)
 
-	# allocate image for whenever
-	img = np.zeros(shape=(height, width, 3), dtype=np.uint8)
+	# start pipelines
+	pipes = pipelineloader.loadall(config, table)
+
+	# push number of pipelines to dashboard
+	table.putNumber('# Pipelines', len(pipes))
 
 	i = 0
 	while True:
 		start_time = time.time()
 
-		table.putNumber('Loop Number', i)
-		i += 1
-
-		t, img = inp.grabFrame(img)
-
-		# process image
-		output_img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+		for pipe in pipes:
+			pipe.process()
 
 		processing_time = time.time() - start_time
 		fps = 1 / processing_time
 		table.putNumber('FPS', fps)
-
-		out.putFrame(output_img)
 
 if __name__ == "__main__":
 	main()

--- a/voidvision/main.py
+++ b/voidvision/main.py
@@ -21,6 +21,7 @@ def main():
 
 	# start pipelines
 	pipes = pipelineloader.loadall(config, table)
+	print(pipes)
 
 	# push number of pipelines to dashboard
 	table.putNumber('# Pipelines', len(pipes))

--- a/voidvision/pipeline.py
+++ b/voidvision/pipeline.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+from abc import ABC, abstractmethod
+
+class VisionPipeline(ABC):
+
+	@abstractmethod
+	def __init__(self, config: str, camera: int, cam_name: str, output_name: str) -> None:
+		pass
+	
+	@abstractmethod
+	def process(self):
+		pass

--- a/voidvision/pipeline.py
+++ b/voidvision/pipeline.py
@@ -11,3 +11,6 @@ class VisionPipeline(ABC):
 	@abstractmethod
 	def process(self):
 		pass
+
+if __name__ == "__main__":
+	print('do not run this script\nsomething is wrong')

--- a/voidvision/pipelineloader.py
+++ b/voidvision/pipelineloader.py
@@ -2,27 +2,31 @@
 
 import importlib
 import json
+import sys
 from pipeline import VisionPipeline
 
-def loadall(config: str, table):
+def loadall(config_file: str, table):
+
+	# insert at 1, 0 is the script path (or '' in REPL)
+	sys.path.insert(1, './pipelines/')
 
 	# list of pipelines
 	piperunners = []
 
 	# read pipelines from config file
-	with open(config) as cfg:
+	with open(config_file) as cfg:
 		config = json.load(cfg)
 	pipes = config['pipelines']
 
 	# initialize and load each pipeline
 	for pipe in pipes:
 		print(pipe)
-		piperunner = load(config, pipe, table)
+		piperunner = load(config_file, pipe, table)
 		piperunners.append(piperunner)
 		
-	return pipes
+	return piperunners
 
-def load(config: str, pipe, table) -> VisionPipeline:
+def load(config_file: str, pipe, table) -> VisionPipeline:
 
 	# read json config for pipeline
 	name = pipe['name']
@@ -31,9 +35,9 @@ def load(config: str, pipe, table) -> VisionPipeline:
 	cam_name = pipe['cameraname']
 
 	# dynamically import/load pipeline
-	module = importlib.import_module('pipelines.'+fname)
+	module = importlib.import_module(fname) # 'voidvision.pipelines.'+fname
 	class_ = getattr(module, name)
-	instance = class_(config, camera, cam_name, (name + '_output'))
+	instance = class_(config_file, camera, cam_name, (name + '_output'))
 
 	# return instance
 	return instance

--- a/voidvision/pipelineloader.py
+++ b/voidvision/pipelineloader.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import importlib
+import json
+from pipeline import VisionPipeline
+
+def loadall(config: str, table):
+
+	# list of pipelines
+	piperunners = []
+
+	# read pipelines from config file
+	with open(config) as cfg:
+		config = json.load(cfg)
+	pipes = config['pipelines']
+
+	# initialize and load each pipeline
+	for pipe in pipes:
+		print(pipe)
+		piperunner = load(config, pipe, table)
+		piperunners.append(piperunner)
+		
+	return pipes
+
+def load(config: str, pipe, table) -> VisionPipeline:
+
+	# read json config for pipeline
+	name = pipe['name']
+	fname = pipe['fname']
+	camera = pipe['camera']
+	cam_name = pipe['cameraname']
+
+	# dynamically import/load pipeline
+	module = importlib.import_module(fname)
+	class_ = getattr(module, name)
+	instance = class_(config, camera, cam_name, (name + '_output'))
+
+	# return instance
+	return instance

--- a/voidvision/pipelineloader.py
+++ b/voidvision/pipelineloader.py
@@ -31,7 +31,7 @@ def load(config: str, pipe, table) -> VisionPipeline:
 	cam_name = pipe['cameraname']
 
 	# dynamically import/load pipeline
-	module = importlib.import_module(fname)
+	module = importlib.import_module('pipelines.'+fname)
 	class_ = getattr(module, name)
 	instance = class_(config, camera, cam_name, (name + '_output'))
 

--- a/voidvision/pipelineloader.py
+++ b/voidvision/pipelineloader.py
@@ -7,7 +7,7 @@ from pipeline import VisionPipeline
 
 def loadall(config_file: str, table):
 
-	# insert at 1, 0 is the script path (or '' in REPL)
+	# insert at pipeline dir 1, 0 is the script path (or '' in REPL)
 	sys.path.insert(1, './pipelines/')
 
 	# list of pipelines
@@ -40,4 +40,7 @@ def load(config_file: str, pipe, table) -> VisionPipeline:
 	instance = class_(config_file, camera, cam_name, (name + '_output'))
 
 	# return instance
-	return instance
+	return name, instance
+
+if __name__ == "__main__":
+	print('do not run this script\nsomething is wrong')

--- a/voidvision/pipelines/test.py
+++ b/voidvision/pipelines/test.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+from voidvision.pipeline import VisionPipeline
+import numpy as np
+import cv2
+
+
+class TestPipeline(VisionPipeline):
+
+	def __init__(self, config: str, camera: int, cam_name: str, output_name: str) -> None:
+
+		# one camera thing
+		self.inp, self.out, self.width, self.height = camera.start(config, camera, cam_name, output_name)
+
+		# allocate image for whenever
+		self.img = np.zeros(shape=(self.height, self.width, 3), dtype=np.uint8)
+		self.output_img = np.zeros(shape=(self.height, self.width, 3), dtype=np.uint8)
+
+	def process(self):
+
+		# get frame from camera
+		self.t, self.img = self.inp.grabFrame(self.img)
+
+		# process image
+		self.output_img = cv2.cvtColor(self.img, cv2.COLOR_BGR2GRAY)
+
+		self.out.putFrame(self.output_img)
+

--- a/voidvision/pipelines/testpipeline.py
+++ b/voidvision/pipelines/testpipeline.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
 
-from voidvision.pipeline import VisionPipeline
+from pipeline import VisionPipeline
+import camera
 import numpy as np
 import cv2
+import sys
 
 
 class TestPipeline(VisionPipeline):
 
-	def __init__(self, config: str, camera: int, cam_name: str, output_name: str) -> None:
+	def __init__(self, config: str, cam_num: int, cam_name: str, output_name: str) -> None:
 
 		# one camera thing
-		self.inp, self.out, self.width, self.height = camera.start(config, camera, cam_name, output_name)
+		self.inp, self.out, self.width, self.height = camera.start(config, cam_num, cam_name, output_name)
 
 		# allocate image for whenever
 		self.img = np.zeros(shape=(self.height, self.width, 3), dtype=np.uint8)
@@ -25,4 +27,3 @@ class TestPipeline(VisionPipeline):
 		self.output_img = cv2.cvtColor(self.img, cv2.COLOR_BGR2GRAY)
 
 		self.out.putFrame(self.output_img)
-

--- a/voidvision/pipelines/testpipeline.py
+++ b/voidvision/pipelines/testpipeline.py
@@ -26,4 +26,5 @@ class TestPipeline(VisionPipeline):
 		# process image
 		self.output_img = cv2.cvtColor(self.img, cv2.COLOR_BGR2GRAY)
 
+		# throw output image to dashboard
 		self.out.putFrame(self.output_img)

--- a/voidvision/vision-config.json
+++ b/voidvision/vision-config.json
@@ -31,7 +31,7 @@
 	"pipelines": [
 		{
 			"name": "TestPipeline",
-			"fname": "test",
+			"fname": "testpipeline",
 			"camera": 0,
 			"cameraname": "cam"
 		}

--- a/voidvision/vision-config.json
+++ b/voidvision/vision-config.json
@@ -27,5 +27,13 @@
 				]
 			}
 		}
-    ]
+    ],
+	"pipelines": [
+		{
+			"name": "TestPipeline",
+			"fname": "test",
+			"camera": 0,
+			"cameraname": "cam"
+		}
+	]
 }


### PR DESCRIPTION
Setup script now adds application to `crontab` and sets up `/etc/hosts` for the robot's network.
Pipeline loader has been added - pipelines can be placed in `voidvision/pipelines/` directory, and configured to run in the config JSON file.